### PR TITLE
When a field is set but it's nil use the default value.

### DIFF
--- a/lib/redis_model/default_values.rb
+++ b/lib/redis_model/default_values.rb
@@ -31,7 +31,7 @@ module RedisModel
     def set_default_values
       self.class.default_values.each do |attr, generator|
         attr_name = attr.to_s
-        @values[attr_name] = generator.call unless @values.key?(attr_name)
+        @values[attr_name] = generator.call if @values[attr_name].nil?
       end
     end
   end

--- a/spec/default_values_spec.rb
+++ b/spec/default_values_spec.rb
@@ -15,4 +15,10 @@ describe RedisModel::CustomSerializers do
 
     expect(person.mash_field).to eq Mash.new
   end
+
+  it 'uses a default value if the field exists but is set to nil' do
+    person = test_class.new(mash_field: nil)
+
+    expect(person.mash_field).to eq Mash.new
+  end
 end


### PR DESCRIPTION
We don't have a NULL equivalent in redis.